### PR TITLE
Fix https://github.com/FreeCAD/FreeCAD-translations/issues/124 (#25)

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -435,9 +435,11 @@ void Application::renameDocument(const char *OldName, const char *NewName)
 
 Document* Application::newDocument(const char * Name, const char * UserName, bool createView, bool tempDoc)
 {
+    QString L10nName = QObject::tr("UnnamedDoc");
     // get a valid name anyway!
     if (!Name || Name[0] == '\0')
-        Name = "Unnamed";
+        Name = qUtf8Printable(L10nName);
+//        Name = (L10nName.toStdString()).c_str();
     string name = getUniqueDocumentName(Name, tempDoc);
 
     // return the temporary document if it exists

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -435,7 +435,7 @@ void Application::renameDocument(const char *OldName, const char *NewName)
 
 Document* Application::newDocument(const char * Name, const char * UserName, bool createView, bool tempDoc)
 {
-    QString L10nName = QObject::tr("UnnamedDoc");
+    QString L10nName = QObject::tr("Unnamed");
     // get a valid name anyway!
     if (!Name || Name[0] == '\0')
         Name = qUtf8Printable(L10nName);

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -128,10 +128,8 @@ SET(FreeCADApp_XML_SRCS
 )
 SOURCE_GROUP("XML" FILES ${FreeCADApp_XML_SRCS})
 
-qt5_add_resources(FreeCADApp_QRC_SRCS Resources/App.qrc)
 # The document stuff
 SET(Document_CPP_SRCS
-    ${FreeCADApp_QRC_SRCS}
     Annotation.cpp
     Document.cpp
     DocumentObject.cpp

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -128,8 +128,10 @@ SET(FreeCADApp_XML_SRCS
 )
 SOURCE_GROUP("XML" FILES ${FreeCADApp_XML_SRCS})
 
+qt5_add_resources(FreeCADApp_QRC_SRCS Resources/App.qrc)
 # The document stuff
 SET(Document_CPP_SRCS
+    ${FreeCADApp_QRC_SRCS}
     Annotation.cpp
     Document.cpp
     DocumentObject.cpp

--- a/src/Mod/Fem/App/AppFemPy.cpp
+++ b/src/Mod/Fem/App/AppFemPy.cpp
@@ -123,7 +123,8 @@ private:
         mesh->read(EncodedName.c_str());
         Base::FileInfo file(EncodedName.c_str());
         // create new document and add Import feature
-        App::Document *pcDoc = App::GetApplication().newDocument("Unnamed");
+        QString newDocumentName = QObject::tr("Unnamed");
+        App::Document *pcDoc = App::GetApplication().newDocument(qUtf8Printable(newDocumentName));
         FemMeshObject *pcFeature = static_cast<FemMeshObject *>
             (pcDoc->addObject("Fem::FemMeshObject", file.fileNamePure().c_str()));
         pcFeature->Label.setValue(file.fileNamePure().c_str());

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -79,7 +79,7 @@
 #include <Mod/Part/App/PartFeaturePy.h>
 
 #include "ImpExpDxf.h"
-
+#include <QObject>
 namespace Import {
 
 class ImportOCAFExt : public Import::ImportOCAF2
@@ -146,7 +146,7 @@ private:
         std::string Utf8Name = std::string(Name);
         PyMem_Free(Name);
         std::string name8bit = Part::encodeFilename(Utf8Name);
-
+        QString newDocumentName = QObject::tr("Unnamed");
         try {
             //Base::Console().Log("Insert in Part with %s",Name);
             Base::FileInfo file(Utf8Name.c_str());
@@ -156,7 +156,7 @@ private:
                 pcDoc = App::GetApplication().getDocument(DocName);
             }
             if (!pcDoc) {
-                pcDoc = App::GetApplication().newDocument("Unnamed");
+                pcDoc = App::GetApplication().newDocument(qUtf8Printable(newDocumentName));
             }
 
             Handle(XCAFApp_Application) hApp = XCAFApp_Application::GetApplication();

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -146,7 +146,7 @@ private:
         std::string Utf8Name = std::string(Name);
         PyMem_Free(Name);
         std::string name8bit = Part::encodeFilename(Utf8Name);
-        QString newDocumentName = QObject::tr("Unnamed");
+        QString newDocumentName = QObject::tr("Unnamed");
         try {
             //Base::Console().Log("Insert in Part with %s",Name);
             Base::FileInfo file(Utf8Name.c_str());

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -411,7 +411,7 @@ private:
         std::string Utf8Name = std::string(Name);
         PyMem_Free(Name);
         std::string name8bit = Part::encodeFilename(Utf8Name);
-
+        QString newDocumentName = QObject::tr("Unnamed");
         try {
             //Base::Console().Log("Insert in Part with %s",Name);
             Base::FileInfo file(Utf8Name.c_str());
@@ -421,7 +421,7 @@ private:
                 pcDoc = App::GetApplication().getDocument(DocName);
             }
             if (!pcDoc) {
-                pcDoc = App::GetApplication().newDocument("Unnamed");
+                pcDoc = App::GetApplication().newDocument(qUtf8Printable(newDocumentName));
             }
 
             Handle(XCAFApp_Application) hApp = XCAFApp_Application::GetApplication();

--- a/src/Mod/Mesh/App/AppMeshPy.cpp
+++ b/src/Mod/Mesh/App/AppMeshPy.cpp
@@ -173,9 +173,9 @@ private:
 
         std::string EncodedName = std::string(Name);
         PyMem_Free(Name);
-
         // create new document and add Import feature
-        App::Document *pcDoc = App::GetApplication().newDocument("Unnamed");
+        QString newDocumentName = QObject::tr("Unnamed");
+        App::Document *pcDoc = App::GetApplication().newDocument(qUtf8Printable(newDocumentName));
 
         Mesh::Importer import(pcDoc);
         import.load(EncodedName);

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -110,7 +110,7 @@
 #include "TopoShapeSolidPy.h"
 #include "TopoShapeWirePy.h"
 #include "TopoShapeVertexPy.h"
-
+#include <QObject>
 #ifdef FCUseFreeType
 #  include "FT2FC.h"
 #endif
@@ -630,14 +630,14 @@ private:
 
         //Base::Console().Log("Open in Part with %s",Name);
         Base::FileInfo file(EncodedName.c_str());
-
+        QString newDocumentName = QObject::tr("Unnamed");
         // extract ending
         if (file.extension().empty())
             throw Py::RuntimeError("No file extension");
-
         if (file.hasExtension("stp") || file.hasExtension("step")) {
             // create new document and add Import feature
-            App::Document *pcDoc = App::GetApplication().newDocument("Unnamed");
+
+            App::Document *pcDoc = App::GetApplication().newDocument(qUtf8Printable(newDocumentName));
 #if 1
             ImportStepParts(pcDoc,EncodedName.c_str());
 #else
@@ -648,7 +648,8 @@ private:
         }
 #if 1
         else if (file.hasExtension("igs") || file.hasExtension("iges")) {
-            App::Document *pcDoc = App::GetApplication().newDocument("Unnamed");
+
+            App::Document *pcDoc = App::GetApplication().newDocument(qUtf8Printable(newDocumentName));
             ImportIgesParts(pcDoc,EncodedName.c_str());
             pcDoc->recompute();
         }

--- a/src/Mod/Path/Gui/AppPathGuiPy.cpp
+++ b/src/Mod/Path/Gui/AppPathGuiPy.cpp
@@ -103,8 +103,9 @@ private:
 
             std::ostringstream pre;
             std::ostringstream cmd;
+            QString newDocumentName = QObject::tr("Unnamed");
             if (processor.empty()) {
-                App::Document *pcDoc = App::GetApplication().newDocument("Unnamed");
+                App::Document *pcDoc = App::GetApplication().newDocument(qUtf8Printable(newDocumentName));
                 Gui::Command::runCommand(Gui::Command::Gui,"import Path");
                 cmd << "Path.read(\"" << EncodedName << "\",\"" << pcDoc->getName() << "\")";
                 Gui::Command::runCommand(Gui::Command::Gui,cmd.str().c_str());

--- a/src/Mod/Points/App/AppPointsPy.cpp
+++ b/src/Mod/Points/App/AppPointsPy.cpp
@@ -45,7 +45,7 @@
 #include "PointsAlgos.h"
 #include "Structured.h"
 #include "Properties.h"
-
+#include <QObject>
 namespace Points {
 class Module : public Py::ExtensionModule<Module>
 {
@@ -112,8 +112,8 @@ private:
             }
 
             reader->read(EncodedName);
-
-            App::Document* pcDoc = App::GetApplication().newDocument("Unnamed");
+            QString newDocumentName = QObject::tr("Unnamed");
+            App::Document* pcDoc = App::GetApplication().newDocument(qUtf8Printable(newDocumentName));
 
             Points::Feature* pcFeature = nullptr;
             if (reader->hasProperties()) {


### PR DESCRIPTION
This solve such things

1.  If you create new document, it show "Unnamed" name without translations. Solved.
2.  If you open .step file create new document with "Unnamed" name without translations. Solved.
3.  If you open .iges file create new document with "Unnamed" name without translations. Solved.
4.  Add similar translation ability to AppFemPy, AppMeshPy and AppPartPy.